### PR TITLE
fix typo which generates segv

### DIFF
--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -366,7 +366,7 @@ static struct flb_config_map config_map[] = {
 
     {
      FLB_CONFIG_MAP_STR, "time_key", FLB_AZURE_TIME_KEY,
-     0, FLB_TRUE, offsetof(struct flb_azure, log_type),
+     0, FLB_TRUE, offsetof(struct flb_azure, time_key),
     "Optional parameter to specify the key name where the timestamp will be stored."
     },
 


### PR DESCRIPTION
because of typo ctx->time_key was not initialized , hence call of flb_sds_len(ctx->time_key) leads to segv

see gdb output here https://pastebin.com/EqwK1Q2i (specifically Line 103)

